### PR TITLE
Solving problem with non existent path on config

### DIFF
--- a/hooks/lib/configXmlParser.js
+++ b/hooks/lib/configXmlParser.js
@@ -122,7 +122,7 @@ function constructHostEntry( xmlElement ) {
  * @return {Array} list of path entries, each on is a JSON object
  */
 function constructPaths( xmlElement ) {
-	if( xmlElement.path == null ) {
+	if( xmlElement.path === null || xmlElement.path === undefined) {
 		return [ "*" ];
 	}
 	let paths = [];

--- a/hooks/lib/configXmlParser.js
+++ b/hooks/lib/configXmlParser.js
@@ -122,10 +122,9 @@ function constructHostEntry( xmlElement ) {
  * @return {Array} list of path entries, each on is a JSON object
  */
 function constructPaths( xmlElement ) {
-	if( xmlElement.path === null ) {
+	if( xmlElement.path == null ) {
 		return [ "*" ];
 	}
-
 	let paths = [];
 	xmlElement.path.some( pathElement => {
 		const url = pathElement.$.url;


### PR DESCRIPTION
When we don't specify a path on the < host />, the XML hook was throwing an error because of this check.

The xmlElement.path is undefined, so the if check should be weak.

It's actually a blocker for me on the newest version :)

Thanks for the great work!